### PR TITLE
WIP: Adds Support for NameValueEntry.

### DIFF
--- a/FSharp.Codecs.Redis/Codecs.fs
+++ b/FSharp.Codecs.Redis/Codecs.fs
@@ -3,6 +3,7 @@ open FSharpPlus
 open FSharpPlus.Data
 open StackExchange.Redis
 open System
+open System.Collections.Concurrent
 
 type Default7 = class end
 type Default6 = class inherit Default7 end
@@ -15,21 +16,41 @@ type Default1 = class inherit Default2 end
 [<AutoOpen>]
 module Redis=
     module Helpers =
-        /// try to find entry with name equal to key
-        let inline tryFindEntry (key:string) (o: HashEntry list) =
+        let inline getNameValue redisKvp = 
+            let name =  (^a : (member get_Name  : unit -> RedisValue ) redisKvp)
+            let value = (^a : (member get_Value : unit -> RedisValue) redisKvp)
+            name, value
+
+        let private getKvPConstructor<'RedisNameValue> =
+            let dict = new ConcurrentDictionary<Type, (RedisValue * RedisValue) -> 'RedisNameValue>()
+            fun () ->
+                let ty = typedefof<'RedisNameValue>
+                dict.GetOrAdd(ty,Func<Type,_>(fun key ->
+                    let ctor = key.GetConstructor [|typeof<RedisValue>; typeof<RedisValue>;|]
+                    let ctorInvoke (name : RedisValue , value : RedisValue) = ctor.Invoke [|box name; box value|]  :?> 'RedisNameValue
+                    ctorInvoke
+                ))
+
+        let constructKvp<'RedisNameValue> (name : RedisValue , value : RedisValue) =
+            getKvPConstructor<'RedisNameValue> () (name,value)
+            
+        let inline tryFindEntry (key : string) (redisKvps : list<_>) =
             let k :RedisValue= implicit key
-            o |> List.tryFind (fun p -> p.Name.Equals(k) ) 
-              |> Option.map (fun v-> v.Value)
+            redisKvps
+            |> List.map(getNameValue)
+            |> List.tryFind(fun (key, _) -> key.Equals k)
+            |> Option.map snd
+
         module HashEntryList=
             let union a b = List.append a b // NOTE: let's start with this, need to verify assumption later
+
     open Helpers
-    type RObject = HashEntry list
 
     type DecodeError =
         | NullString of System.Type
         | IndexOutOfRange of int * RedisValue
         | InvalidValue of System.Type * RedisValue * string
-        | PropertyNotFound of string * RObject
+        | PropertyNotFound of string * obj
         | ParseError of System.Type * exn * string
         | Uncategorized of string
         | Multiple of DecodeError list
@@ -191,7 +212,7 @@ module Redis=
       )
 
     /// Creates a new Redis key,value pair for a Redis object
-    let inline rpairWith toRedis (key: string) value = HashEntry(implicit key, toRedis value) 
+    let inline rpairWith toRedis (key: string) value = constructKvp (implicit key, toRedis value) 
 
     /// Creates a new Redis key,value pair for a Redis object
     let inline rpair (key: string) value = rpairWith toRedis key value
@@ -202,22 +223,22 @@ module Redis=
 
 
     /// Gets a value from a Redis object
-    let inline rgetWith ofRedis (o: RObject) key =
+    let inline rgetWith ofRedis o key =
         match tryFindEntry key o with
         | Some value -> ofRedis value
         | _ -> Decode.Fail.propertyNotFound key o
     /// Gets a value from a Redis object
-    let inline rget (o: RObject) key = rgetWith ofRedis o key
+    let inline rget o key = rgetWith ofRedis o key
 
     // Tries to get a value from a Redis object.
     /// Returns None if key is not present in the object.
-    let inline rgetOptWith ofRedis (o: RObject) key =
+    let inline rgetOptWith ofRedis o key =
         match tryFindEntry key o with
         | Some value -> ofRedis value |> map Some
         | _ -> Success None
     /// Tries to get a value from a Redis object.
     /// Returns None if key is not present in the object.
-    let inline rgetOpt (o: RObject) key = rgetOptWith ofRedis o key
+    let inline rgetOpt o key = rgetOptWith ofRedis o key
 
     /// <summary>Appends a field mapping to the codec.</summary>
     /// <param name="codec">The codec to be used.</param>
@@ -228,8 +249,8 @@ module Redis=
     let inline rfieldWith codec fieldName (getter: 'T -> 'Value) (rest: SplitCodec<_, _ -> 'Rest, _>) =
         let inline deriveFieldCodec codec prop getter =
             (
-                (fun (o: RObject) -> rgetWith (fst codec) o prop),
-                (getter >> fun (x: 'Value) -> [HashEntry(implicit prop, ((snd codec) x))])
+                (fun (o) -> rgetWith (fst codec) o prop),
+                (getter >> fun (x: 'Value) -> [constructKvp (implicit prop, ((snd codec) x))])
             )
         diApply HashEntryList.union rest (deriveFieldCodec codec fieldName getter)
 
@@ -249,8 +270,8 @@ module Redis=
     let inline rfieldOptWith codec fieldName (getter: 'T -> 'Value option) (rest: SplitCodec<_, _ -> 'Rest, _>) =
         let inline deriveFieldCodecOpt codec prop getter =
             (
-                (fun (o: RObject) -> rgetOptWith (fst codec) o prop),
-                (getter >> function Some (x: 'Value) -> [HashEntry(implicit prop, ((snd codec) x))] | _ -> [])
+                (fun (o) -> rgetOptWith (fst codec) o prop),
+                (getter >> function Some (x: 'Value) -> [constructKvp(implicit prop, ((snd codec) x))] | _ -> [])
             )
         diApply HashEntryList.union rest (deriveFieldCodecOpt codec fieldName getter)
 
@@ -308,22 +329,22 @@ module Operators =
     let inline (^=) a b = (a, b)
 
     /// Gets a value from a Redis object
-    let inline rgetFromListWith ofRedis (o: list<HashEntry>) key =
+    let inline rgetFromListWith ofRedis o key =
       match tryFindEntry key o with
       | Some value -> ofRedis value
-      | _ -> Decode.Fail.propertyNotFound key (ofList o)
+      | _ -> Decode.Fail.propertyNotFound key (o)
 
     /// Tries to get a value from a Redis object.
     /// Returns None if key is not present in the object.
-    let inline rgetFromListOptWith ofRedis (o: list<HashEntry>) key =
+    let inline rgetFromListOptWith ofRedis (o: list<_>) key =
       match tryFindEntry key o with
       | Some value -> ofRedis value |> map Some
       | _ -> Ok None
 
     let inline roptWith codec prop getter =
       {
-          Decoder = ReaderT (fun (o: list<HashEntry>) -> rgetFromListOptWith (fst codec) o prop)
-          Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [HashEntry (implicit prop, (snd codec) x)] | _ -> [])
+          Decoder = ReaderT (fun (o: list<_>) -> rgetFromListOptWith (fst codec) o prop)
+          Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [constructKvp (implicit prop, (snd codec) x)] | _ -> [])
       }
 
     /// Derives a concrete field codec for an optional field
@@ -331,8 +352,8 @@ module Operators =
 
     let inline rreqWith codec (prop: string) (getter: 'T -> 'Value option) =
       {
-          Decoder = ReaderT (fun (o: list<HashEntry>) -> rgetFromListWith (fst codec) o prop)
-          Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [HashEntry (implicit prop, (snd codec) x)] | _ -> [])
+          Decoder = ReaderT (fun (o: list<_>) -> rgetFromListWith (fst codec) o prop)
+          Encoder = fun x -> Const (match getter x with Some (x: 'Value) -> [constructKvp (implicit prop, (snd codec) x)] | _ -> [])
       }
 
     /// Derives a concrete field codec for a required field

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -12,7 +12,9 @@ type Person = {
 type Person with
     static member Create name age = { Person.Name = name; Age = age }
 
-    static member OfRedis o = 
+    static member OfRedis (o : HashEntry list) = 
+        Person.Create <!> (o .@ "name") <*> (o .@ "age")
+    static member OfRedis (o : NameValueEntry list) = 
         Person.Create <!> (o .@ "name") <*> (o .@ "age")
         
 
@@ -29,7 +31,13 @@ type Item = {
 }
 
 type Item with
-    static member RedisObjCodec =
+    static member RedisObjCodecHashEntry =
+        fun id brand availability -> { Item.Id = id; Brand = brand; Availability = availability }
+        <!> rreq  "id"          (fun x -> Some x.Id     )
+        <*> rreq  "brand"       (fun x -> Some x.Brand  )
+        <*> ropt "availability" (fun x -> x.Availability)
+        |> Codec.ofConcrete
+    static member RedisObjCodecNameValueEntry =
         fun id brand availability -> { Item.Id = id; Brand = brand; Availability = availability }
         <!> rreq  "id"          (fun x -> Some x.Id     )
         <*> rreq  "brand"       (fun x -> Some x.Brand  )
@@ -39,29 +47,47 @@ type Item with
 open FsCheck
 open FsCheck.GenOperators
 let personHashEntries = [ HashEntry(implicit "name", implicit "John"); HashEntry(implicit "age", implicit 44) ]
+let personNameValueEntries = [ NameValueEntry(implicit "name", implicit "John"); NameValueEntry(implicit "age", implicit 44) ]
 let person = { Person.Name = "John"; Age = 44 }
 let itemHashEntries = [HashEntry(implicit "id", implicit 11); HashEntry(implicit "brand", implicit "Spinal trap")]
+let itemNameValueEntries = [NameValueEntry(implicit "id", implicit 11); NameValueEntry(implicit "brand", implicit "Spinal trap")]
 let item = {Id=11; Brand="Spinal trap"; Availability= None}
 let tests = [
         testList "From Redis" [
 
-            test "Person" {
+            test "Person HashEntry" {
                 let actual : Person ParseResult =Person.OfRedis personHashEntries
                 Assert.Equal("Person", Ok person, actual)
             }
-            test "Item" {
-                let actual : Item ParseResult = Codec.decode Item.RedisObjCodec itemHashEntries
+            test "Person NameValueEntry" {
+                let actual : Person ParseResult =Person.OfRedis personNameValueEntries
+                Assert.Equal("Person", Ok person, actual)
+            }
+            test "Item HashEntry" {
+                let actual : Item ParseResult = Codec.decode Item.RedisObjCodecHashEntry itemHashEntries
+                Assert.Equal("Item", Ok item, actual)
+            }
+            test "Item NameValueEntry" {
+                let actual : Item ParseResult = Codec.decode Item.RedisObjCodecNameValueEntry itemNameValueEntries
                 Assert.Equal("Item", Ok item, actual)
             }
         ]
         testList "To Redis" [
-            test "Person" {
+            test "Person HashEntry" {
                 let actual = Person.ToRedis person
                 Assert.Equal("Person", personHashEntries, actual)
             }
-            test "Item" {
-                let actual = Codec.encode Item.RedisObjCodec item
+            test "Person HashEntry" {
+                let actual = Person.ToRedis person
+                Assert.Equal("Person", personNameValueEntries, actual)
+            }
+            test "Item HashEntry" {
+                let actual = Codec.encode Item.RedisObjCodecHashEntry item
                 Assert.Equal("Item", itemHashEntries, actual)
+            }
+            test "Item NameValueEntry" {
+                let actual = Codec.encode Item.RedisObjCodecNameValueEntry item
+                Assert.Equal("Item", itemNameValueEntries, actual)
             }
         ]
     ]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# -*- coding: utf-8 -*-
+
+set -eu
+set -o pipefail
+
+dotnet build FSharp.Codecs.Redis.sln -c Release
+dotnet pack FSharp.Codecs.Redis -c Release


### PR DESCRIPTION
Closes #4 

Adds Support for NameValueEntry. Technically this adds support for anything that follows the given conventions:

- Has a constructor that takes two `RedisValue`s as a Name, Value tuple.
- Has 2 member functions, one that returns a `RedisValue` for Name and another that returns a `RedisValue` for Value.

---

Still WIP since I'm unsure how to handle `PropertyNotFound` now that there is no `RObject`