### PR TITLE
Converts HashEntry to using KeyValuePairs and implicit converts to Redis types

### DIFF
--- a/FSharp.Codecs.Redis/Codecs.fs
+++ b/FSharp.Codecs.Redis/Codecs.fs
@@ -19,14 +19,14 @@ module Redis=
         let inline getNameValue redisKvp = 
             let name =  (^a : (member get_Name  : unit -> RedisValue ) redisKvp)
             let value = (^a : (member get_Value : unit -> RedisValue) redisKvp)
-            KeyValuePair(name, value)
+            name, value
         /// try to find entry with name equal to key
         let inline tryFindEntry (key:string) (o: list<_>) =
             let k :RedisValue= implicit key
             o 
             |> List.map getNameValue
-            |> List.tryFind (fun p -> p.Key.Equals(k) ) 
-            |> Option.map (fun v-> v.Value)
+            |> List.tryFind (fun (p,_) -> p.Equals(k) ) 
+            |> Option.map snd
         module RedisList=
             let union a b = List.append a b // NOTE: let's start with this, need to verify assumption later
     open Helpers
@@ -211,7 +211,7 @@ module Redis=
     let inline rgetWith ofRedis kvps key =
         match tryFindEntry key kvps with
         | Some value -> ofRedis value
-        | _ -> Decode.Fail.propertyNotFound key (List.map getNameValue kvps)
+        | _ -> Decode.Fail.propertyNotFound key (List.map implicit kvps)
     /// Gets a value from a Redis object
     let inline rget kvps key = rgetWith ofRedis kvps key
 
@@ -317,7 +317,7 @@ module Operators =
     let inline rgetFromListWith ofRedis (o: list<_>) key =
       match tryFindEntry key o with
       | Some value -> ofRedis value
-      | _ -> Decode.Fail.propertyNotFound key (List.map getNameValue o)
+      | _ -> Decode.Fail.propertyNotFound key (List.map implicit o)
 
     /// Tries to get a value from a Redis object.
     /// Returns None if key is not present in the object.

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -12,11 +12,19 @@ type Person = {
 type Person with
     static member Create name age = { Person.Name = name; Age = age }
 
-    static member OfRedis o = 
+    static member OfRedis (o : HashEntry list) = 
+        Person.Create <!> (o .@ "name") <*> (o .@ "age")
+        
+    static member OfRedis (o : NameValueEntry list) = 
         Person.Create <!> (o .@ "name") <*> (o .@ "age")
         
 
-    static member ToRedis (x: Person) =
+    static member ToHashEntry (x: Person) : HashEntry list =
+        [ 
+            "name" .= x.Name
+            "age" .= x.Age
+        ]
+    static member ToNameValueEntry (x: Person) : NameValueEntry list =
         [ 
             "name" .= x.Name
             "age" .= x.Age
@@ -29,7 +37,13 @@ type Item = {
 }
 
 type Item with
-    static member RedisObjCodec =
+    static member RedisObjCodecHashEntry =
+        fun id brand availability -> { Item.Id = id; Brand = brand; Availability = availability }
+        <!> rreq  "id"          (fun x -> Some x.Id     )
+        <*> rreq  "brand"       (fun x -> Some x.Brand  )
+        <*> ropt "availability" (fun x -> x.Availability)
+        |> Codec.ofConcrete
+    static member RedisObjCodecNameValueEntry =
         fun id brand availability -> { Item.Id = id; Brand = brand; Availability = availability }
         <!> rreq  "id"          (fun x -> Some x.Id     )
         <*> rreq  "brand"       (fun x -> Some x.Brand  )
@@ -39,29 +53,47 @@ type Item with
 open FsCheck
 open FsCheck.GenOperators
 let personHashEntries = [ HashEntry(implicit "name", implicit "John"); HashEntry(implicit "age", implicit 44) ]
+let personNameValueEntries = [ NameValueEntry(implicit "name", implicit "John"); NameValueEntry(implicit "age", implicit 44) ]
 let person = { Person.Name = "John"; Age = 44 }
 let itemHashEntries = [HashEntry(implicit "id", implicit 11); HashEntry(implicit "brand", implicit "Spinal trap")]
+let itemNameValueEntries = [NameValueEntry(implicit "id", implicit 11); NameValueEntry(implicit "brand", implicit "Spinal trap")]
 let item = {Id=11; Brand="Spinal trap"; Availability= None}
 let tests = [
         testList "From Redis" [
 
-            test "Person" {
+            test "Person HashEntry" {
                 let actual : Person ParseResult =Person.OfRedis personHashEntries
                 Assert.Equal("Person", Ok person, actual)
             }
-            test "Item" {
-                let actual : Item ParseResult = Codec.decode Item.RedisObjCodec itemHashEntries
+            test "Person NameValueEntry" {
+                let actual : Person ParseResult =Person.OfRedis personNameValueEntries
+                Assert.Equal("Person", Ok person, actual)
+            }
+            test "Item HashEntry" {
+                let actual : Item ParseResult = Codec.decode Item.RedisObjCodecHashEntry itemHashEntries
+                Assert.Equal("Item", Ok item, actual)
+            }
+            test "Item NameValueEntry" {
+                let actual : Item ParseResult = Codec.decode Item.RedisObjCodecNameValueEntry itemNameValueEntries
                 Assert.Equal("Item", Ok item, actual)
             }
         ]
         testList "To Redis" [
-            test "Person" {
-                let actual = Person.ToRedis person
+            test "Person HashEntry" {
+                let actual = Person.ToHashEntry person
                 Assert.Equal("Person", personHashEntries, actual)
             }
-            test "Item" {
-                let actual = Codec.encode Item.RedisObjCodec item
+            test "Person NameValueEntry" {
+                let actual = Person.ToNameValueEntry person
+                Assert.Equal("Person", personNameValueEntries, actual)
+            }
+            test "Item HashEntry" {
+                let actual = Codec.encode Item.RedisObjCodecHashEntry item
                 Assert.Equal("Item", itemHashEntries, actual)
+            }
+            test "Item NameValueEntry" {
+                let actual = Codec.encode Item.RedisObjCodecNameValueEntry item
+                Assert.Equal("Item", itemNameValueEntries, actual)
             }
         ]
     ]


### PR DESCRIPTION
Closes #4 

Many of the Redis types such as HashEntryand NameValueEntry allow for implicit converts to those types via a KeyValuePair. This changes the internal implementation to use KeyValuePairs and implicit converts so this can support more types than only HashEntry.
